### PR TITLE
Basic improvements to code review tool

### DIFF
--- a/.templates/branchdiff.tpl
+++ b/.templates/branchdiff.tpl
@@ -22,6 +22,7 @@
  {include file='title.tpl'}
 
  <div class="page_body">
+   <div class="diff_summary">
    {if $branchdiff && !$sidebyside}
        {if $extensions}
            <div class="file_filter">
@@ -67,6 +68,7 @@
       <script type="text/javascript" src="/lib/mergely/mergely.js"></script>
       <link type="text/css" rel="stylesheet" href="/lib/mergely/mergely.css" />
    {/if}
+   </div>
 
      {if $branchdiff && $sidebyside}
     <div class="commitDiffSBS">

--- a/.templates/commitdiff.tpl
+++ b/.templates/commitdiff.tpl
@@ -28,6 +28,7 @@
  {include file='title.tpl' titlecommit=$commit}
 
  <div class="page_body">
+   <div class="diff_summary">
    {assign var=bugpattern value=$project->GetBugPattern()}
    {assign var=bugurl value=$project->GetBugUrl()}
    {foreach from=$commit->GetComment() item=line}
@@ -72,6 +73,8 @@
       <script type="text/javascript" src="/lib/mergely/mergely.js"></script>
       <link type="text/css" rel="stylesheet" href="/lib/mergely/mergely.css" />
      {/if}
+   </div>
+
      {if $sidebyside}
     <div class="commitDiffSBS">
 

--- a/css/gitphpskin.css
+++ b/css/gitphpskin.css
@@ -15,8 +15,6 @@
 body {
 	font-family: sans-serif;
 	font-size: 14px;
-	border: solid #d9d8d1;
-	border-width: 1px;
 	margin: 10px;
 	background-color: #ffffff;
 	color: #000000;
@@ -134,9 +132,9 @@ div.page_footer_text {
 
 
 /*
- * Page body
+ * Diff summary
  */
-div.page_body { 
+div.diff_summary {
 	padding: 8px; 
 }
 
@@ -393,6 +391,7 @@ div.diff_info {
 	color: #000099; 
 	background-color: #edece6; 
 	font-style: italic; 
+	padding: 8px;
 }
 
 .diffplus {
@@ -405,6 +404,12 @@ div.diff_info {
 
 .diffat {
 	color: #990099;
+}
+
+.diffBlob {
+	border: solid #d9d8d1;
+	border-width: 1px;
+	margin-bottom: 16px;
 }
 
 

--- a/css/review.css
+++ b/css/review.css
@@ -25,6 +25,7 @@ span.btn_small {
     border: 1px solid #888 !important;
     padding-left: 4px !important;
     padding-right: 4px !important;
+    cursor: pointer;
 }
 
 #review_text {

--- a/js/review.js
+++ b/js/review.js
@@ -491,6 +491,9 @@ var Review = (function() {
 
     Review.selectEnd = function(e) {
         var $target = $(e.target);
+        if (!$target.hasClass('line-number') && !$target.hasClass('btn_small')) {
+            return;
+        }
         if ($target.hasClass("line-number") && $target.parent().children("CODE").length == 0) {
             return;
         }

--- a/lib/syntaxhighlighter/styles/shThemeDefault.css
+++ b/lib/syntaxhighlighter/styles/shThemeDefault.css
@@ -27,7 +27,15 @@
 }
 .syntaxhighlighter .line.color3:hover, .syntaxhighlighter .line.color4:hover, .syntaxhighlighter .line.commentable:hover {
     background-color: rgba(192, 192, 192, 0.3) !important;
+}
+.syntaxhighlighter .line.commentable .line-number {
     cursor: pointer;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 .syntaxhighlighter .line.selected {
     border: 2px solid #080  !important;


### PR DESCRIPTION
Code review tool improvements:
- Register "click" action to line numbers only, not the whole line
- Keep line highlighting troughout the whole line and use "auto" cursor
- ~~Do not copy/paste line numbers when selecting blocks of code~~ _Works in Firefox only_ 

Make diff page prettier:
- Separate files more nicely, similar to Github/Gitlab interface