### PR TITLE
Fix bug with missing base param and incomplete tag selector

### DIFF
--- a/.templates/branchdiff.tpl
+++ b/.templates/branchdiff.tpl
@@ -14,14 +14,14 @@
 
     <strong>Change diff mode</strong>
     {if $sidebyside}
-      <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;o=unified">{t}unified{/t}</a>
-      | <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;o=treediff">{t}treediff{/t}</a>
+      <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;{if $base}base={$base}{/if}&amp;o=unified">{t}unified{/t}</a>
+      | <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;{if $base}base={$base}{/if}&amp;o=treediff">{t}treediff{/t}</a>
     {elseif $unified}
-      <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;o=sidebyside">{t}side by side{/t}</a>
-      | <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;o=treediff">{t}treediff{/t}</a>
+      <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;{if $base}base={$base}{/if}&amp;o=sidebyside">{t}side by side{/t}</a>
+      | <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;{if $base}base={$base}{/if}&amp;o=treediff">{t}treediff{/t}</a>
     {else}
-      <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;o=unified">{t}unified{/t}</a>
-      | <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;o=sidebyside">{t}side by side{/t}</a>
+      <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;{if $base}base={$base}{/if}&amp;o=unified">{t}unified{/t}</a>
+      | <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff&amp;branch={$branch}&amp;{if $review}review={$review}{/if}&amp;{if $base}base={$base}{/if}&amp;o=sidebyside">{t}side by side{/t}</a>
     {/if}
 
    | <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=branchdiff_plain&amp;branch={$branch}">{t}plain{/t}</a>

--- a/js/diff.js
+++ b/js/diff.js
@@ -97,7 +97,7 @@ function detectActiveBlobs() {
     // Find the file name and highlight on the left pane
     const fileName = closestBlob.find('a.anchor').attr('name');
     $('.file-list li').removeClass('is-active');
-    $(`.file-list a[href="#${fileName}"`).parent().addClass('is-active');
+    $(`.file-list a[href="#${fileName}"]`).parent().addClass('is-active');
 }
 
 function renderFolder(folder) {


### PR DESCRIPTION
@uyga  This fixes a bug where if you have a branchdiff between a branch and a base the base param is not preserved when switching diff modes.

It also fixes a bug in Safari because I forgot to close the "[" tag in selector. Chrome was able to somehow make it work but Safari doesn't