### PR TITLE
Bug fix: Allow reviews on zeroth line

### DIFF
--- a/js/review.js
+++ b/js/review.js
@@ -348,7 +348,7 @@ var Review = (function() {
                         var file = data.comments[i].file;
                         var line = parseInt(data.comments[i].line);
                         var lines_count = parseInt(data.comments[i].lines_count) || 0;
-                        var real_line = parseInt(data.comments[i].real_line);
+                        var real_line = parseInt(data.comments[i].real_line) || undefined;
                         if (data.comments[i].side) {
                             real_line = real_line + 1;
                         }


### PR DESCRIPTION
@uyga Right now there is a bug in ngit. You can't leave comments on the diff line of a file (This used to work in old gitphp)

I saw that there is some code difference in new gitphp vs old. I am not sure why this was removed but this fixes the bug. Please have a look.

Steps to reproduce:

- Open a diff
- Review any of the first three lines

ER: Review comment is visible
AR: Review comment disappears