### PR TITLE
Allow review comments from 0th line in sbs mode

### DIFF
--- a/js/sbs_review.js
+++ b/js/sbs_review.js
@@ -116,7 +116,10 @@ SideBySideReview.prototype = {
                             if (!$('#comment' + comment_data.id).length) {
                                 review.addComment(
                                     comment_side,
-                                    {from: line_from, to: line_from + parseInt(comment_data.lines_count) - 1},
+                                    {
+                                        from: line_from,
+                                        to: Math.max(line_from, line_from + parseInt(comment_data.lines_count) - 1)
+                                    },
                                     comment_data.text,
                                     parseInt(comment_data.id),
                                     comment_data.status == 'Draft',


### PR DESCRIPTION
@uyga  Fixed 0th line comments on sbs mode. You still can't make comments on 0th line because it doesn't exist but at least you can see them now.