### PR TITLE
Fix multiline comments and improve scroll behaviour in unified+treedifgf mode

### DIFF
--- a/css/gitphpskin.css
+++ b/css/gitphpskin.css
@@ -486,6 +486,7 @@ div.commitDiffSBS div.SBSTOC
 {
 	word-wrap: break-word;
 	overflow: scroll;
+	height: calc(100vh - 100px);
 }
 
 div.commitDiffSBS div.SBSTOC a

--- a/css/review.css
+++ b/css/review.css
@@ -305,6 +305,7 @@ span.review {
   padding-top: 10px;
   padding-bottom: 10px;
   font-family: "SF UI Text", Helvetica, Arial, sans-serif !important;
+  white-space: pre-line;
 }
 
 .cloud_with_text.sbs {

--- a/css/treediff.css
+++ b/css/treediff.css
@@ -4,10 +4,9 @@
 	-webkit-flex-direction: row;
 	flex-direction: row;
 	align-content: stretch;
-	height: calc(100vh - 100px);
 }
 
-.has-review-block .two-panes {
+.has-review-block div.commitDiffSBS div.SBSTOC {
 	height: calc(100vh - 120px);
 }
 
@@ -16,6 +15,10 @@
 	overflow: scroll;
 	padding: 0 0 10px 0;
 	min-width: 200px;
+	position: sticky;
+	top: 0;
+	align-self: flex-start;
+	max-height: 90vh;
 }
 
 .two-panes .pane-dragger {
@@ -192,4 +195,3 @@
 
 .page_body.only-comments .right-pane .diffBlob.has-review-comment {
     display: block;
-}


### PR DESCRIPTION
This fixes the rendering of multi-line comments and improves the scrolling behaviour in unified + treediff mode. (Now the file list is sticky to the left and content can be scrolled normally instead of having dual-scrolling)

SBS mode is not affected.