### PR TITLE
Fixes to scrolling pane + overlapping of review panel

### DIFF
--- a/css/gitphp.css
+++ b/css/gitphp.css
@@ -181,7 +181,7 @@ p.too_large_diff img {
 }
 
 div.suppressed {
-    background-color: #d9d8d1;
+    background-color: #f9f9f9;
 }
 
 .hidden {

--- a/css/gitphpskin.css
+++ b/css/gitphpskin.css
@@ -22,7 +22,6 @@ body {
 	background-color: white;
 	color: #303030;
 	margin: 0;
-	height: 100%;
 	min-height: 100%;
 	font-family: "SF UI Text", Helvetica, Arial, sans-serif;
 }

--- a/css/treediff.css
+++ b/css/treediff.css
@@ -4,6 +4,7 @@
 	-webkit-flex-direction: row;
 	flex-direction: row;
 	align-content: stretch;
+	min-height: calc(100vh - 100px);
 }
 
 .two-panes .left-pane {
@@ -12,8 +13,13 @@
 	padding: 0 0 10px 0;
 	min-width: 200px;
 	position: sticky;
-	top: 0;
+	top: 10px;
 	align-self: flex-start;
+	max-height: calc(100vh - 20px);
+}
+
+.has-review-block .two-panes .left-pane {
+	max-height: calc(100vh - 100px);
 }
 
 .two-panes .pane-dragger {


### PR DESCRIPTION
- Fixed a bug in treediff view where some content was hidden behind review panel
- Fixed issues when cicking on files in treediff would jump the whole window causing the tree to be lost