### PR TITLE
Fix issue with folder containing spaces

### DIFF
--- a/js/diff.js
+++ b/js/diff.js
@@ -148,7 +148,7 @@ function enablePaneDragging() {
 }
 
 function detectActiveBlobs() {
-    const hash = window.location.hash.substr(1);
+    const hash = decodeURIComponent(window.location.hash.substr(1));
     const foundElement = $(`[name="${hash}"]`);
     const closestBlob = foundElement.closest('.diffBlob');
     closestBlob.addClass('is-visible').siblings().removeClass('is-visible');


### PR DESCRIPTION
When reading hashes the folder paths with spaces have %20 in them. However the file names in git have the labels as spaces. This meant that clicking on files which belong to a folder with a space broke the DOM lookup