### PR TITLE
add everywhere read-only access mode for users

### DIFF
--- a/.include/controller/GitosisUsers.php
+++ b/.include/controller/GitosisUsers.php
@@ -4,11 +4,12 @@ namespace GitPHP\Controller;
 
 class GitosisUsers extends GitosisBase
 {
-    const ACCESS_MODE_NORMAL = 'normal';
-    const ACCESS_MODE_ALLOW_ALL = 'everywhere';
+    const ACCESS_MODE_NORMAL       = 'normal';
+    const ACCESS_MODE_ALLOW_ALL    = 'everywhere';
+    const ACCESS_MODE_ALLOW_ALL_RO = 'everywhere-ro';
 
     protected $edit_user;
-    protected $access_modes = [self::ACCESS_MODE_NORMAL, self::ACCESS_MODE_ALLOW_ALL];
+    protected $access_modes = [self::ACCESS_MODE_NORMAL, self::ACCESS_MODE_ALLOW_ALL, self::ACCESS_MODE_ALLOW_ALL_RO];
 
     protected function ReadQuery()
     {
@@ -63,9 +64,7 @@ class GitosisUsers extends GitosisBase
         parent::LoadData();
 
         $this->tpl->assign('users', $this->ModelGitosis->getUsers());
-
         $this->tpl->assign('access_modes', $this->access_modes);
-
         $this->tpl->assign('edit_user', $this->edit_user);
     }
 

--- a/.setup/local/schema.sql
+++ b/.setup/local/schema.sql
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS `User` (
   `username` varchar(128) NOT NULL,
   `email` varchar(256) NOT NULL DEFAULT '',
   `public_key` text NOT NULL,
-  `access_mode` enum('normal','everywhere') NOT NULL DEFAULT 'normal',
+  `access_mode` enum('normal','everywhere', 'everywhere-ro') NOT NULL DEFAULT 'normal',
   `comment` text,
   `created` timestamp NULL DEFAULT NULL,
   `updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/.templates/gitosisaccess.tpl
+++ b/.templates/gitosisaccess.tpl
@@ -23,11 +23,11 @@
             <tr class="{cycle values="light,dark"}" id="{$user.username}">
                 <td>
                     <p>{$user.username}</p>
-                    {if $user.access_mode == 'everywhere'}<small class="warning">only restricted repos shown</small>{/if}
+                    {if $user.access_mode == 'everywhere' || $user.access_mode == 'everywhere-ro'}<small class="warning">only restricted repos shown</small>{/if}
                 </td>
                 <td>
                     <select name="projects_ids[]" multiple="" size="10" class='select-input'>
-                    {if $user.access_mode == 'everywhere'}
+                    {if $user.access_mode == 'everywhere' || $user.access_mode == 'everywhere-ro'}
                         {foreach from=$restricted_projects item=project}
                             <option value="{$project.id}">{$project.project}</option>
                         {/foreach}


### PR DESCRIPTION
this might be useful for some system users like teamcity agents: they
need to be able to pull changes in all repositories without having
possibility to modify anything