### PR TITLE
Fixes for indentation of folders in project list

### DIFF
--- a/css/gitphpskin.css
+++ b/css/gitphpskin.css
@@ -1122,9 +1122,17 @@ ul.owners-list {
 	font-size: 16px;
 }
 
-.git-table .subProjectFolder th,
-.git-table .subProjectFolder td:first-child {
-	border-left: 30px solid transparent;
+.git-table .categoryRow,
+.git-table .subProjectFolder {
+	cursor: pointer;
+}
+
+.git-table .subProjectFolder th {
+	padding-left: 50px;
+}
+
+.git-table .subProjectFolder td:nth-child(2) {
+	padding-left: 50px;
 }
 
 .git-table td.code-search-results > * {


### PR DESCRIPTION
- When there is only one project with a subfolder we should not indent it
- Fix some styling of folder indentation
- Remove duplicate folder name if it's already part of a group