### PR TITLE
Update dockerfile to make it work again

### DIFF
--- a/.setup/Dockerfile
+++ b/.setup/Dockerfile
@@ -1,17 +1,23 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 MAINTAINER Ilya Ageev <iamuyga@gmail.com>
 
 ENV MYSQL_ROOT_PASSWORD root
+ENV DEBIAN_FRONTEND noninteractive
 
-RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu trusty main" > /etc/apt/sources.list.d/ondrej-php-trusty.list \
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        gnupg
+
+RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" > /etc/apt/sources.list.d/ondrej-php-bionic.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C \
-    && bash -c "debconf-set-selections <<< 'mysql-server-5.6 mysql-server/root_password password $MYSQL_ROOT_PASSWORD'" \
-    && bash -c "debconf-set-selections <<< 'mysql-server-5.6 mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD'"
+    && bash -c "debconf-set-selections <<< 'mysql-server-5.7 mysql-server/root_password password $MYSQL_ROOT_PASSWORD'" \
+    && bash -c "debconf-set-selections <<< 'mysql-server-5.7 mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD'" \
+    && echo "Etc/UTC" > /etc/timezone
 
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
         nginx \
-        mysql-server-5.6 \
+        mysql-server-5.7 \
         php7.0-curl \
         php7.0-fpm \
         php7.0-gd \
@@ -43,4 +49,3 @@ VOLUME /local/codeisok
 
 EXPOSE 80 22
 CMD bash /local/init.sh && bash
-

--- a/.setup/Dockerfile
+++ b/.setup/Dockerfile
@@ -49,4 +49,4 @@ VOLUME /home/git
 VOLUME /local/codeisok
 
 EXPOSE 80 22
-CMD bash /local/init.sh && bash
+CMD bash /local/init.sh

--- a/.setup/Dockerfile
+++ b/.setup/Dockerfile
@@ -2,19 +2,20 @@ FROM ubuntu:18.04
 MAINTAINER Ilya Ageev <iamuyga@gmail.com>
 
 ENV MYSQL_ROOT_PASSWORD root
-ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update -y \
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update -y \
     && apt-get install -y --no-install-recommends \
-        gnupg
+        gnupg \
+        software-properties-common
 
-RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" > /etc/apt/sources.list.d/ondrej-php-bionic.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4F4EA0AAE5267A6C \
+RUN add-apt-repository ppa:ondrej/php \
     && bash -c "debconf-set-selections <<< 'mysql-server-5.7 mysql-server/root_password password $MYSQL_ROOT_PASSWORD'" \
     && bash -c "debconf-set-selections <<< 'mysql-server-5.7 mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD'" \
-    && echo "Etc/UTC" > /etc/timezone
+    && echo "UTC" > /etc/timezone
 
-RUN apt-get update -y \
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update -y \
     && apt-get install -y --no-install-recommends \
         nginx \
         mysql-server-5.7 \

--- a/.setup/etc/mysql/my.cnf
+++ b/.setup/etc/mysql/my.cnf
@@ -48,29 +48,29 @@ bind-address		= 0.0.0.0
 #
 # * Fine Tuning
 #
-key_buffer		= 16M
+key_buffer_size	= 16M
 max_allowed_packet	= 16M
 thread_stack		= 192K
-thread_cache_size       = 8
+thread_cache_size	= 8
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched
-myisam-recover         = BACKUP
-#max_connections        = 100
-#table_cache            = 64
-#thread_concurrency     = 10
+myisam-recover-options	= BACKUP
+#max_connections	= 100
+#table_cache		= 64
+#thread_concurrency	= 10
 #
 # * Query Cache Configuration
 #
 query_cache_limit	= 1M
-query_cache_size        = 16M
+query_cache_size	= 16M
 #
 # * Logging and Replication
 #
 # Both location gets rotated by the cronjob.
 # Be aware that this log type is a performance killer.
 # As of 5.1 you can enable the log at runtime!
-#general_log_file        = /var/log/mysql/mysql.log
-#general_log             = 1
+#general_log_file	= /var/log/mysql/mysql.log
+#general_log		= 1
 #
 # Error log - should be very few entries.
 #
@@ -87,7 +87,7 @@ log_error = /var/log/mysql/error.log
 #server-id		= 1
 #log_bin			= /var/log/mysql/mysql-bin.log
 expire_logs_days	= 10
-max_binlog_size         = 100M
+max_binlog_size	= 100M
 #binlog_do_db		= include_database_name
 #binlog_ignore_db	= include_database_name
 #

--- a/.setup/etc/mysql/my.cnf
+++ b/.setup/etc/mysql/my.cnf
@@ -1,3 +1,4 @@
+# vim: softtabstop=0 tabstop=8 noexpandtab shiftwidth=8 :
 #
 # The MySQL database server configuration file.
 #
@@ -87,7 +88,7 @@ log_error = /var/log/mysql/error.log
 #server-id		= 1
 #log_bin			= /var/log/mysql/mysql-bin.log
 expire_logs_days	= 10
-max_binlog_size	= 100M
+max_binlog_size		= 100M
 #binlog_do_db		= include_database_name
 #binlog_ignore_db	= include_database_name
 #

--- a/.setup/local/init.sh
+++ b/.setup/local/init.sh
@@ -10,7 +10,6 @@ fi
 
 service mysql start
 service php7.0-fpm start
-service nginx start
 service ssh start
 
 mysql -uroot -proot < /local/schema.sql
@@ -31,3 +30,11 @@ hostname=$(hostname)
 localhost=$(head -n 1 /etc/hosts | awk '{print $2}')
 echo "127.0.0.1 $localhost $localhost.localdomain $hostname $hostname.localdomain" >> /etc/hosts
 service sendmail start
+
+if [ -t 1 ]; then
+    // Interactive mode, stdout is terminal
+    service nginx start
+    bash
+else
+    nginx -g 'daemon off;'
+fi

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,8 @@ Docker container exposes 2 ports:
  * 80 for HTTP instance (http://localhost/).
  * 22 as ssh-source for git operations (ssh://git@localhost/testrepo.git)
 
+To run container in non-interactive mode (background) - replace `-it` options with `-d` one in `docker run` command
+
 ### Internals
 
 Default authorisation is just config-based. You can use 'user' user and 'password' password. To change it look for \GitPHP_Config::AUTH_METHOD and \GitPHP_Config::CONFIG_AUTH_USER fields in .config/gitphp.conf.php file.


### PR DESCRIPTION
php7 for 14.04 is no longer available in PPA.
The easiest way to install it into container I found is base image version update.