### PR TITLE
Use JS to load large diffs in treediff mode

### DIFF
--- a/.include/controller/Branchdiff.php
+++ b/.include/controller/Branchdiff.php
@@ -155,9 +155,6 @@ class Branchdiff extends DiffBase
         if (in_array($this->project->GetCategory(), \GitPHP\Config::GetInstance()->GetValue(\GitPHP\Config::SKIP_SUPPRESS_FOR_CATEGORY, []))) {
             $DiffContext->setSkipSuppress(true);
         }
-        if ($this->params['treediff'] ?? false) {
-            $DiffContext->setSkipSuppress(true);
-        }
         $branchdiff = new \GitPHP_BranchDiff($this->project, $this->params['branch'], $this->params['base'], $DiffContext);
         if ($toHash) $branchdiff->SetToHash($toHash);
         if (preg_match('/[0-9a-f]{40}/i', $this->params['base'])) {

--- a/.include/controller/Commitdiff.php
+++ b/.include/controller/Commitdiff.php
@@ -132,10 +132,6 @@ class Commitdiff extends DiffBase
             ->setIgnoreWhitespace($this->params['ignorewhitespace'])
             ->setIgnoreFormatting($this->params['ignoreformat']);
 
-        if ($this->params['treediff'] ?? false) {
-            $DiffContext->setSkipSuppress(true);
-        }
-
         $commit_tree_diff = new \GitPHP_TreeDiff(
             $this->project,
             $this->params['hash'],

--- a/js/diff.js
+++ b/js/diff.js
@@ -99,7 +99,6 @@ function renderTreeDiff(fileList, container) {
     enablePaneDragging();
     enableFolderCollapsing();
 
-
     $('.two-panes').removeClass('is-loading');
 }
 
@@ -126,7 +125,7 @@ function enablePaneDragging() {
         isDragging = true;
         dragStart = e.clientX;
         leftPaneWidth = leftPane.width();
-        
+
         $(document.body)
             .on('mouseup', onMouseUp)
             .on('mousemove', onMouseMove);
@@ -134,7 +133,7 @@ function enablePaneDragging() {
 
     function onMouseUp() {
         isDragging = false;
-        
+
         $(document.body)
             .off('mouseup', onMouseUp)
             .off('mousemove', onMouseMove);
@@ -167,6 +166,12 @@ function detectActiveBlobs() {
     if (foundElement.length > 0) {
         foundElement.get(0).scrollIntoView();
     }
+
+    const suppressedDiff = closestBlob.find('.show_suppressed_diff');
+    if (suppressedDiff.length > 0) {
+        suppressedDiff.click();
+    }
+
 }
 
 function getReviewKey() {


### PR DESCRIPTION
We had logic in PHP to load large diffs in treediff mode, this caused JS errors because huge files like XCode configs were automatically expanded.

Now we use an async solution for this, and do it automatically when a user selects the file