### PR TITLE
fix syntax in docker's init-file

### DIFF
--- a/.setup/local/init.sh
+++ b/.setup/local/init.sh
@@ -32,7 +32,7 @@ echo "127.0.0.1 $localhost $localhost.localdomain $hostname $hostname.localdomai
 service sendmail start
 
 if [ -t 1 ]; then
-    // Interactive mode, stdout is terminal
+    # Interactive mode, stdout is terminal
     service nginx start
     bash
 else


### PR DESCRIPTION
By some strange reason in .sh file `//` used for a comment, instead of `#`