### PR TITLE
BugFix - Show file names for renamed files in SBS and Blob diffs.

### DIFF
--- a/.templates/blobdiff.tpl
+++ b/.templates/blobdiff.tpl
@@ -52,7 +52,7 @@
                     {if $filediff->GetToFile()}{$filediff->GetToFile()}{else}{$filediff->GetToHash()}{/if} {t}(new){/t}
                 {elseif $filediff->GetStatus() == 'D'}
                     {if $filediff->GetFromFile()}{$filediff->GetFromFile()}{else}{$filediff->GetToFile()}{/if} {t}(deleted){/t}
-                {elseif $filediff->GetStatus() == 'M'}
+                {elseif ($filediff->GetStatus() == 'M') || ($filediff->GetStatus() == 'R')}
                     {if $filediff->GetFromFile()}
                         {assign var=fromfilename value=$filediff->GetFromFile()}
                     {else}

--- a/.templates/sbs_non_treediff.tpl
+++ b/.templates/sbs_non_treediff.tpl
@@ -13,7 +13,7 @@
                         {if $filediff->GetToFile()}{$filediff->GetToFile()}{else}{$filediff->GetToHash()}{/if} {t}(new){/t}
                     {elseif $filediff->GetStatus() == 'D'}
                         {if $filediff->GetFromFile()}{$filediff->GetFromFile()}{else}{$filediff->GetToFile()}{/if} {t}(deleted){/t}
-                    {elseif $filediff->GetStatus() == 'M'}
+                    {elseif ($filediff->GetStatus() == 'M') || ($filediff->GetStatus() == 'R')}
                         {if $filediff->GetFromFile()}
                             {assign var=fromfilename value=$filediff->GetFromFile()}
                         {else}


### PR DESCRIPTION
In SBS mode if a file is renamed we never show the name of it.

![image](https://user-images.githubusercontent.com/87832/75352870-57404f00-58a2-11ea-9421-f1e6f8b8fa51.png)
