### PR TITLE
Prevent reload of page on first review comment

### DIFF
--- a/js/review.js
+++ b/js/review.js
@@ -187,14 +187,16 @@ var Review = (function() {
             }
             Review.hideForm();
             $('#review_text').val('');
+
             if (!Review.getUrlParams().review) {
-                location = location.protocol + '//' + location.host + location.pathname + location.search + '&review=' + data.review_id + '#' + data.comment_id;
+                history.replaceState(null, null, location.search + '&review=' + data.review_id + '#' + data.comment_id);
             } else {
                 location.hash = data.comment_id;
-                Review.showComments();
-                $('#review_finish').show();
-                $('#review_abort').show();
             }
+
+            Review.showComments();
+            $('#review_finish').show();
+            $('#review_abort').show();
         }, 'json')
             .error(Review.saveError).complete(Review.reviewSaveComplete);
     };


### PR DESCRIPTION
To me it seems like the whole reason we had to reload the page on first review comment was to add a URL param. With `history.replaceState` this is not needed anymore.

This will be a significant UX improvement for developers. However I will need some help testing it, as I might have not forseen some edge cases.

I have tested the following scenarios:

- Side by side review comment
- Unified review comment
- Browser navigation after leaving comments