### PR TITLE
Always show full commit details on the details page

### DIFF
--- a/.templates/title.tpl
+++ b/.templates/title.tpl
@@ -25,7 +25,7 @@
                     {foreach from=$titlecommit->GetComment() item=line key=key}
                         {* First line is always the original commit title which we render above *}
                         {if $key !== 0 && trim($line) !== ""}
-                            {$line|htmlspecialchars|buglink:$bugpattern:$bugurl}<br />
+                            {$line|htmlspecialchars}<br />
                         {/if}
                     {/foreach}
                 </div>

--- a/.templates/title.tpl
+++ b/.templates/title.tpl
@@ -20,6 +20,16 @@
                 {else}
                     <a href="{$SCRIPT_NAME}?p={$project->GetProject()|urlencode}&amp;a=commit&amp;h={$titlecommit->GetHash()}" class="title">{$titlecommit->GetTitle()|escape}</a>
                 {/if}
+
+                <div>
+                    {foreach from=$titlecommit->GetComment() item=line key=key}
+                        {* First line is always the original commit title which we render above *}
+                        {if $key !== 0 && trim($line) !== ""}
+                            {$line|htmlspecialchars|buglink:$bugpattern:$bugurl}<br />
+                        {/if}
+                    {/foreach}
+                </div>
+
                 {include file='refbadges.tpl' commit=$titlecommit}
             {else}
                 {if $target == 'shortlog'}

--- a/css/gitphpskin.css
+++ b/css/gitphpskin.css
@@ -289,11 +289,11 @@ div.title {
 }
 
 div.title.stretch-evenly {
-	line-height: 40px;
+	line-height: 1.5em;
 }
 
 div.title.compact {
-	padding: 10px 20px 10px 0;
+	padding: 20px 20px 20px 0;
 	border: 0;
 	font-size: 14px;
 }


### PR DESCRIPTION
We never showed full commit info on the detail page, it means developers miss critical information in the UI

**Before**

![image](https://user-images.githubusercontent.com/87832/79144250-46a95100-7ddc-11ea-801f-446968a773ec.png)


**After**

![image](https://user-images.githubusercontent.com/87832/79144212-372a0800-7ddc-11ea-9596-3073111452b0.png)
