### PR TITLE
Enable gzip for better performance and fix bug with folders in treediff

### DIFF
--- a/.setup/etc/nginx/nginx.conf
+++ b/.setup/etc/nginx/nginx.conf
@@ -23,6 +23,7 @@ http {
 
     gzip on;
     gzip_disable "msie6";
+    gzip_types text/plain text/css application/xml application/x-javascript application/javascript application/json;
 
     include /etc/nginx/mime.types;
     default_type application/octet-stream;

--- a/js/diff.js
+++ b/js/diff.js
@@ -367,7 +367,7 @@ function getFolderMap(fileList) {
             }
 
             // If no folder found then make one
-            let foundFolder = currentFolder.find(item => item.name === folder);
+            let foundFolder = currentFolder.find(item => item.type === 'folder' && item.name === folder);
             if (!foundFolder) {
                 foundFolder = {
                     type: 'folder',


### PR DESCRIPTION
We had JS error in treediff if a folder was found with a single file which was moved.

Gzip enables much faster loads for pages with large diffs.