### PR TITLE
The cookie for codeisok should last for a year

### DIFF
--- a/.include/Session.php
+++ b/.include/Session.php
@@ -94,7 +94,10 @@ class Session
     protected function start()
     {
         $is_started = function_exists('session_status') ? session_status() === PHP_SESSION_ACTIVE : session_id() !== '';
-        if (!$is_started) session_start();
+        if (!$is_started) {
+            session_set_cookie_params(60 * 60 * 24 * 365);
+            session_start();
+        }
     }
 
     protected function initUser()


### PR DESCRIPTION
It doesn't make sense to have such a short lived cookie, this causes a lot of problems due to "disappearing reviews".

This fixes https://github.com/badoo/codeisok/issues/99